### PR TITLE
Improve schedule management UI and role options

### DIFF
--- a/index.html
+++ b/index.html
@@ -367,6 +367,7 @@
           <label>권한</label>
           <select id="adminRegisterRole" onchange="toggleRegisterSubCategory()">
             <option value="관리자">관리자</option>
+            <option value="일정관리자">일정관리자</option>
             <option value="본사">본사</option>
             <option value="협력">협력</option>
           </select>
@@ -549,9 +550,18 @@
     <label style="font-size: 0.8em;">본사 담당자</label>
     <select id="modalManagerSelect" style="width: 100%; box-sizing: border-box; font-size: 0.8em;"></select>
   </div>
-  <div style="flex: 1; min-width: 0;">
+  <div style="flex: 0.5; min-width: 0;">
     <label style="font-size: 0.8em;">AS NO.</label>
     <input type="text" id="modalAsNo" style="width: 100%; box-sizing: border-box; font-size: 0.8em;">
+  </div>
+  <div style="flex: 0.5; min-width: 0;">
+    <label style="font-size: 0.8em;">AS 구분</label>
+    <select id="modalAsType" style="width: 100%; box-sizing: border-box; font-size: 0.8em;">
+      <option value="">-- 선택 --</option>
+      <option value="유상">유상</option>
+      <option value="무상">무상</option>
+      <option value="위탁">위탁</option>
+    </select>
   </div>
 </div>
 
@@ -729,6 +739,7 @@
         <label>권한</label>
         <select id="userEditRole">
           <option value="관리자">관리자</option>
+          <option value="일정관리자">일정관리자</option>
           <option value="본사">본사</option>
           <option value="협력">협력</option>
         </select>


### PR DESCRIPTION
## Summary
- support AS type selection on the schedule modal
- expose new `일정관리자` role in user forms
- include Shipowner and AS type in Excel downloads
- filter Excel download by selected period
- add helpers for admin-like roles and user editing

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_b_688c2a1f854883249ff3f59b3e1b3d51